### PR TITLE
Fix collapsed groups hiding search results

### DIFF
--- a/frontend/web-interface/src/JobLogsPage.tsx
+++ b/frontend/web-interface/src/JobLogsPage.tsx
@@ -417,7 +417,7 @@ const JobLogsPage = () => {
                             ) : (
                                 <div className="logs-list">
                                     {filteredLogs.map((log, index) => {
-                                        if (!log.isGroupHeader && log.groupId && collapsedGroups.has(log.groupId)) {
+                                        if (!log.isGroupHeader && log.groupId && collapsedGroups.has(log.groupId) && searchTerm === '') {
                                             return null;
                                         }
 


### PR DESCRIPTION
Search results were hidden when inside collapsed groups. Now collapsed state is ignored when search is active.